### PR TITLE
Make lint-on-save and format-on-save configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,39 @@ Just barebone Janet language mode, copied from the clojure.kak, for [Kakoune][1]
 ### With [plug.kak][2] (recommended)
 
 Just add this to your `kakrc`:
+
 ```kak
 plug "pepe/janet.kak"
 ```
+
 Then reload Kakoune config or restart Kakoune and run `:plug-install`.
 
 ### Formatting
 
-To use auto format on save, you need to install [jfmt][3]
+To use auto format on save, you need to install [jfmt][3] and update your `kakrc` like so:
+
+```kak
+set-option global janet_autoformat true
+set-option global janet_formatcmd jfmt
+```
 
 ### Linting
 
-To use auto lint before save, you need to install [jlnt][4]
+To use auto lint before save, you need to install [jlnt][4] and update your `kakrc` like so:
+
+```kak
+set-option global janet_autolint true
+set-option global janet_lintcmd jlnt
+```
+
+### User Mappings
+
+`janet.kak` provides a user mode with various mappings to access Janet doc strings, surround forms with delimiters, paste some common snippets, and more.
+To access this user mode, you need to add a mapping to the default user mode.
+
+```kak
+map global user -docstring 'Janet mode' J ': enter-user-mode janet<ret>'
+```
 
 [1]: https://github.com/mawww/kakoune
 [2]: https://github.com/andreyorst/plug.kak


### PR DESCRIPTION
I personally do not prefer doing linting or formatting on save as it may cause confusing diffs in contributions to other projects if I autoformat every file I modify. However, janet.kak previously hardcoded this functionality, and I couldn't even disable it as the hooks had no group, so I had to remove that part of the code locally. Since I'd prefer not maintaining a fork, I decided to come up with a more constructive solution, which was simply defining config options that can be included in kakrc like so:

```kak
plug "pepe/janet.kak" config %{
    set-option global janet_autoformat true
    set-option global janet_autolint true
}
```

Additionally I made some miscellaneous changes:
 - Normal mode mapping of `<a-space>` is removed and a snippet of how the user can access the Janet user mode is added to README. It is unidiomatic to define normal mode mappings in Kakoune plugins but you can feel free to define them in your personal kakrc.
 - Default commands for linter and formatter are no longer hardcoded to `/usr/local/bin`; now they simply expect the command to be in PATH. Users can feel free to override this new behavior by setting `janet_formatcmd` or `janet_lintcmd`.

Thank you for making this plugin, it's nice to see other Kakoune users out there. :)
